### PR TITLE
Improve claims serialization

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -13,8 +13,8 @@
     <MicrosoftAspNetCoreTestHostVersion>2.2.0</MicrosoftAspNetCoreTestHostVersion>
     <FluentAssertionsVersion>5.6.0</FluentAssertionsVersion>
     <MicrosoftAspNetCoreAllVersion>2.2.0</MicrosoftAspNetCoreAllVersion>
-    <MicrosoftWebCodeGenerationVersion>2.2.0</MicrosoftWebCodeGenerationVersion>
-    <MicrosoftWebCodeGenerationToolsVersion>2.2.0</MicrosoftWebCodeGenerationToolsVersion>
+    <MicrosoftWebCodeGenerationVersion>2.2.1</MicrosoftWebCodeGenerationVersion>
+    <MicrosoftWebCodeGenerationToolsVersion>2.2.1</MicrosoftWebCodeGenerationToolsVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="CLI Tools Versions">
@@ -27,7 +27,7 @@
     <RepositoryUrl>http://github.com/xabaril/Acheve.TestHost</RepositoryUrl>    
     <Authors>Xabaril Contributors</Authors>
     <Company>Xabaril</Company>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <Description>Achve.TestHost is a nuget package to improve TestServer experiences.
     For more information see http://github.com/Xabaril/Acheve.TestHost</Description>
     <Tags>TestHost;TestServer</Tags>

--- a/samples/Sample.Api/Controllers/ValuesController.cs
+++ b/samples/Sample.Api/Controllers/ValuesController.cs
@@ -7,7 +7,7 @@ namespace Sample.Api.Controllers
     [ApiController]
     public class ValuesController : ControllerBase
     {
-        [Authorize]
+        [Authorize(Policy = "ValidateClaims")]
         [HttpGet]
         public IActionResult Values()
         {

--- a/samples/Sample.IntegrationTests/Identities.cs
+++ b/samples/Sample.IntegrationTests/Identities.cs
@@ -7,8 +7,13 @@ namespace Sample.IntegrationTests
     {
         public static readonly IEnumerable<Claim> User = new[]
         {
-            new Claim(ClaimTypes.NameIdentifier, "1"),
-            new Claim(ClaimTypes.Name, "User"),
+            new Claim(
+                type: ClaimTypes.NameIdentifier,
+                value: "1",
+                valueType: ClaimValueTypes.Integer32,
+                issuer: "TestIssuer",
+                originalIssuer: "OriginalTestIssuer"),
+            new Claim(type: ClaimTypes.Name, value: "User"),
         };
 
         public static readonly IEnumerable<Claim> Empty = new Claim[0];

--- a/samples/Sample.IntegrationTests/Specs/ValuesTests.cs
+++ b/samples/Sample.IntegrationTests/Specs/ValuesTests.cs
@@ -31,15 +31,13 @@ namespace Sample.IntegrationTests.Specs
         }
 
         [Fact]
-        public async Task User_With_No_Claims_Is_Unauthorized()
+        public async Task User_With_No_Claims_Is_Forbidden()
         {
             var response = await _fixture.Server.CreateHttpApiRequest<ValuesController>(controller => controller.Values())
                 .WithIdentity(Identities.Empty)
                 .GetAsync();
 
-            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
-            response.Headers.WwwAuthenticate.Count.Should().Be(1);
-            response.Headers.WwwAuthenticate.First().Scheme.Should().Be("TestServer");
+            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
         }
 
         [Fact]


### PR DESCRIPTION
Right now only the claim type and the claim value are serialized in the authentication header used by the library. This is far from perfect scenario because there could be potential complex authorization workflows that take into account more information about the user claims. Not only the type and the value. For example validate the Issuer or the ClaimValueType or extended properties in the claim.
This Pull Request include a change in the serialization of the claims information. It uses now the *TicketSerializer* included in the *Microsoft.AspNetCore.Authentication* package that include all the information included in the claims that are specified in the tests.