### PR TITLE
Add extension methods to build an authentication header

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -27,7 +27,7 @@
     <RepositoryUrl>http://github.com/xabaril/Acheve.TestHost</RepositoryUrl>    
     <Authors>Xabaril Contributors</Authors>
     <Company>Xabaril</Company>
-    <Version>2.2.1</Version>
+    <Version>2.3.0</Version>
     <Description>Achve.TestHost is a nuget package to improve TestServer experiences.
     For more information see http://github.com/Xabaril/Acheve.TestHost</Description>
     <Tags>TestHost;TestServer</Tags>

--- a/src/Acheve.TestHost/HttpClientExtensions.cs
+++ b/src/Acheve.TestHost/HttpClientExtensions.cs
@@ -50,5 +50,41 @@ namespace System.Net.Http
 
             return httpClient;
         }
+
+        /// <summary>
+        /// Get the header string for the provided claims
+        /// </summary>
+        /// <param name="httpClient">The httpClient instance</param>
+        /// <param name="claims">The claims collection that represents the user identity</param>
+        /// <returns></returns>
+        public static string GetHeaderForIdentity(this HttpClient httpClient, IEnumerable<Claim> claims)
+        {
+            return httpClient.GetHeaderForIdentity(
+                claims,
+                TestServerDefaults.AuthenticationScheme);
+        }
+
+        /// <summary>
+        /// Get the header string for the provided claims
+        /// </summary>
+        /// <param name="httpClient">The httpClient instance</param>
+        /// <param name="claims">The claims collection that represents the user identity</param>
+        /// <param name="scheme">The authentication scheme</param>
+        /// <returns></returns>
+        public static string GetHeaderForIdentity(this HttpClient httpClient, IEnumerable<Claim> claims, string scheme)
+        {
+            if (string.IsNullOrWhiteSpace(scheme))
+            {
+                throw new ArgumentNullException(nameof(scheme));
+            }
+
+            var headerName = AuthenticationHeaderHelper.GetHeaderName(scheme);
+
+            var header = new NameValueHeaderValue(
+                headerName,
+                $"{TestServerDefaults.AuthenticationScheme} {DefautClaimsEncoder.Encode(claims)}");
+
+            return header.ToString();
+        }
     }
 }

--- a/src/Acheve.TestHost/RequestBuilderExtensions.cs
+++ b/src/Acheve.TestHost/RequestBuilderExtensions.cs
@@ -2,6 +2,7 @@
 using Acheve.TestHost;
 using System.Collections.Generic;
 using System.Security.Claims;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.TestHost
 {
@@ -16,14 +17,9 @@ namespace Microsoft.AspNetCore.TestHost
         /// <returns></returns>
         public static RequestBuilder WithIdentity(this RequestBuilder requestBuilder, IEnumerable<Claim> claims)
         {
-            var headerName =
-                AuthenticationHeaderHelper.GetHeaderName(TestServerDefaults.AuthenticationScheme);
-
-            requestBuilder.AddHeader(
-                headerName,
-                $"{TestServerDefaults.AuthenticationScheme} {DefautClaimsEncoder.Encode(claims)}");
-
-            return requestBuilder;
+            return requestBuilder.WithIdentity(
+                claims,
+                TestServerDefaults.AuthenticationScheme);
         }
 
         /// <summary>
@@ -48,6 +44,42 @@ namespace Microsoft.AspNetCore.TestHost
                 $"{scheme} {DefautClaimsEncoder.Encode(claims)}");
 
             return requestBuilder;
+        }
+
+        /// <summary>
+        /// Get the header string for the provided claims
+        /// </summary>
+        /// <param name="requestBuilder">The requestBuilder instance</param>
+        /// <param name="claims">The claims collection that represents the user identity</param>
+        /// <returns></returns>
+        public static string GetHeaderForIdentity(this RequestBuilder requestBuilder, IEnumerable<Claim> claims)
+        {
+            return requestBuilder.GetHeaderForIdentity(
+                claims,
+                TestServerDefaults.AuthenticationScheme);
+        }
+
+        /// <summary>
+        /// Get the header string for the provided claims
+        /// </summary>
+        /// <param name="requestBuilder">The requestBuilder instance</param>
+        /// <param name="claims">The claims collection that represents the user identity</param>
+        /// <param name="scheme">The authentication scheme</param>
+        /// <returns></returns>
+        public static string GetHeaderForIdentity(this RequestBuilder requestBuilder, IEnumerable<Claim> claims, string scheme)
+        {
+            if (string.IsNullOrWhiteSpace(scheme))
+            {
+                throw new ArgumentNullException(nameof(scheme));
+            }
+
+            var headerName = AuthenticationHeaderHelper.GetHeaderName(scheme);
+
+            var header = new NameValueHeaderValue(
+                headerName,
+                $"{TestServerDefaults.AuthenticationScheme} {DefautClaimsEncoder.Encode(claims)}");
+
+            return header.ToString();
         }
     }
 }


### PR DESCRIPTION
Add extension methods to get the authentication header that should be included in the request.
This enables scenarios where the header must be included manually in the request.