### PR TITLE
* added logic of apicontroller where the [frombody] 

### DIFF
--- a/src/Acheve.TestHost/Routing/AttributeTemplates/AttributeVerbsTemplate.cs
+++ b/src/Acheve.TestHost/Routing/AttributeTemplates/AttributeVerbsTemplate.cs
@@ -20,12 +20,16 @@ namespace Acheve.TestHost.Routing.AttributeTemplates
             var putAttributes = action.MethodInfo.GetCustomAttributes<HttpPutAttribute>()
                 .OfType<HttpMethodAttribute>();
 
+            var patchAttributes = action.MethodInfo.GetCustomAttributes<HttpPatchAttribute>()
+                .OfType<HttpMethodAttribute>();
+
             var deleteAttributes = action.MethodInfo.GetCustomAttributes<HttpDeleteAttribute>()
                 .OfType<HttpMethodAttribute>();
 
             var verbAttribute = getAttributes
                 .Union(postAttributes)
                 .Union(putAttributes)
+                .Union(patchAttributes)
                 .Union(deleteAttributes)
                 .SingleOrDefault();
 

--- a/src/Acheve.TestHost/Routing/TestServerAction.cs
+++ b/src/Acheve.TestHost/Routing/TestServerAction.cs
@@ -26,10 +26,11 @@ namespace Acheve.TestHost.Routing
             var isFromBody = argument.GetCustomAttributes<FromBodyAttribute>().Any();
             var isFromForm = argument.GetCustomAttributes<FromFormAttribute>().Any();
             var isFromHeader = argument.GetCustomAttributes<FromHeaderAttribute>().Any();
-          
-            bool isPrimitive = argument.ParameterType.IsPrimitive || argument.ParameterType.Name.Equals(typeof(string));
 
-            if (activeBodyApiController && !isFromBody && !isPrimitive)
+            bool isPrimitive = argument.ParameterType.IsPrimitive || argument.ParameterType.Name.Equals(typeof(string));
+            bool hasNoAttributes = !isFromBody && !isFromForm && !isFromHeader;
+
+            if (activeBodyApiController && hasNoAttributes && !isPrimitive)
             {
                 isFromBody = true;
             }

--- a/src/Acheve.TestHost/Routing/TestServerAction.cs
+++ b/src/Acheve.TestHost/Routing/TestServerAction.cs
@@ -20,11 +20,17 @@ namespace Acheve.TestHost.Routing
             ArgumentValues = new Dictionary<int, TestServerArgument>();
         }
 
-        public void AddArgument(int order, Expression expression)
+        public void AddArgument(int order, Expression expression, bool activeBodyApiController)
         {
             var argument = MethodInfo.GetParameters()[order];
             var isFromBody = argument.GetCustomAttributes<FromBodyAttribute>().Any();
             var isFromForm = argument.GetCustomAttributes<FromFormAttribute>().Any();
+            bool isPrimitive = argument.ParameterType.IsPrimitive || argument.ParameterType.Name.Equals(typeof(string));
+
+            if (activeBodyApiController && !isFromBody && !isPrimitive)
+            {
+                isFromBody = true;
+            }
 
             if (!ArgumentValues.ContainsKey(order))
             {

--- a/src/Acheve.TestHost/Routing/Tokenizers/ComplexParameterActionTokenizer.cs
+++ b/src/Acheve.TestHost/Routing/Tokenizers/ComplexParameterActionTokenizer.cs
@@ -25,7 +25,8 @@ namespace Acheve.TestHost.Routing.Tokenizers
                             var tokenName = property.Name.ToLowerInvariant();
                             var value = property.GetValue(action.ArgumentValues[i].Instance);
 
-                            tokens.AddToken(tokenName, value.ToString(), isConventional: false);
+                            if (value != null)
+                                tokens.AddToken(tokenName, value.ToString(), isConventional: false);
                         }
                     }
                 }

--- a/src/Acheve.TestHost/TestServerExtensions.cs
+++ b/src/Acheve.TestHost/TestServerExtensions.cs
@@ -144,12 +144,15 @@ namespace Microsoft.AspNetCore.TestHost
             var methodCall = (MethodCallExpression)actionSelector.Body;
 
             var action = new TestServerAction(methodCall.Method);
+            bool haveAttributeApiController = typeof(TController).GetTypeInfo().GetCustomAttribute(typeof(ApiControllerAttribute)) != null;
+            bool isGetOrDelete  = action.MethodInfo.GetCustomAttributes().FirstOrDefault(attr => attr.GetType() == typeof(HttpGetAttribute)
+                                                                                                 || attr.GetType() == typeof(HttpDeleteAttribute)) != null;
 
             int index = 0;
 
             foreach (var item in methodCall.Arguments)
             {
-                action.AddArgument(index, item);
+                action.AddArgument(index, item, haveAttributeApiController && !isGetOrDelete);
 
                 ++index;
             }

--- a/src/Acheve.TestHost/TestServerExtensions.cs
+++ b/src/Acheve.TestHost/TestServerExtensions.cs
@@ -148,7 +148,7 @@ namespace Microsoft.AspNetCore.TestHost
             var action = new TestServerAction(methodCall.Method);
             bool haveAttributeApiController = typeof(TController).GetTypeInfo().GetCustomAttribute(typeof(ApiControllerAttribute)) != null;
             bool isGetOrDelete  = action.MethodInfo.GetCustomAttributes().FirstOrDefault(attr => attr.GetType() == typeof(HttpGetAttribute)
-                                                                                                 || attr.GetType() == typeof(HttpDeleteAttribute)) != null;
+                                                                                         || attr.GetType() == typeof(HttpDeleteAttribute)) != null;
 
             var index = 0;
 

--- a/tests/UnitTests/Acheve.TestHost/Routing/Builders/ValuesV5Controller.cs
+++ b/tests/UnitTests/Acheve.TestHost/Routing/Builders/ValuesV5Controller.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace UnitTests.Acheve.TestHost.Builders
+{
+    [Route("api/values")]
+    [ApiController]
+    public class ValuesV5Controller : ControllerBase
+    {
+        [HttpPost]
+        public IActionResult Post1(Pagination pagination)
+        {
+            return Ok();
+        }
+
+        [HttpPost("{id:int}")]
+        public IActionResult Post2(int id, Pagination pagination1)
+        {
+            if (pagination1 == null)
+            {
+                return BadRequest();
+            }
+
+            return Ok();
+        }
+
+        [HttpPatch("{id:int}")]
+        public IActionResult Patch1(int id, Pagination pagination1)
+        {
+            if (pagination1 == null)
+            {
+                return BadRequest();
+            }
+
+            return Ok();
+        }
+    }
+}

--- a/tests/UnitTests/Acheve.TestHost/Routing/TestServerExtensionsTests.cs
+++ b/tests/UnitTests/Acheve.TestHost/Routing/TestServerExtensionsTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 using UnitTests.Acheve.TestHost.Builders;
 using Xunit;
@@ -736,9 +737,9 @@ namespace UnitTests.Acheve.TestHost.Routing
 
             var requestPost2 = server.CreateHttpApiRequest<ValuesV3Controller>(
                controller => controller.Post6(header, complexParameter));
+
             requestPost2.GetRequest().Headers.GetValues("custom").First().Should().Be(header);
-            requestPost2.GetConfiguredAddress()
-                .Should().Be("api/values/post6");
+            requestPost2.GetConfiguredAddress().Should().Be("api/values/post6");
         }
 
         [Fact]
@@ -1267,6 +1268,65 @@ namespace UnitTests.Acheve.TestHost.Routing
 
             request.GetConfiguredAddress()
                 .Should().Be($"api/bugs/prm1/{guidValue}");
+        }
+
+        [Fact]
+        public void create_valid_request_without_using_frombody_with_apicontroller_attribute()
+        {
+            var server = new TestServerBuilder().UseDefaultStartup()
+                                                .Build();
+
+            var complexParameter = new Pagination()
+            {
+                PageCount = 10,
+                PageIndex = 1
+            };
+
+            var requestPost1 = server.CreateHttpApiRequest<ValuesV5Controller>(controller => controller.Post1(complexParameter));
+
+            string body = requestPost1.GetRequest().Content.ReadAsStringAsync().Result;
+            JsonSerializer.Deserialize<Pagination>(body).PageIndex.Should().Be(complexParameter.PageIndex);
+            JsonSerializer.Deserialize<Pagination>(body).PageCount.Should().Be(complexParameter.PageCount);
+        }
+
+        [Fact]
+        public void create_valid_request_without_using_frombody_with_apicontroller_attribute_and_route_parameter()
+        {
+            var server = new TestServerBuilder().UseDefaultStartup()
+                                                .Build();
+
+            var complexParameter = new Pagination()
+            {
+                PageCount = 10,
+                PageIndex = 1
+            };
+
+            var requestPost2 = server.CreateHttpApiRequest<ValuesV5Controller>(controller => controller.Post2(1, complexParameter));
+
+            string body = requestPost2.GetRequest().Content.ReadAsStringAsync().Result;
+            JsonSerializer.Deserialize<Pagination>(body).PageIndex.Should().Be(complexParameter.PageIndex);
+            JsonSerializer.Deserialize<Pagination>(body).PageCount.Should().Be(complexParameter.PageCount);
+            requestPost2.GetConfiguredAddress().StartsWith("api/values/1").Should().Be(true);
+        }
+
+        [Fact]
+        public void create_valid_request_of_patch_without_using_frombody_with_apicontroller_attribute_and_route_parameter()
+        {
+            var server = new TestServerBuilder().UseDefaultStartup()
+                                                .Build();
+
+            var complexParameter = new Pagination()
+            {
+                PageCount = 10,
+                PageIndex = 1
+            };
+
+            var requestPost2 = server.CreateHttpApiRequest<ValuesV5Controller>(controller => controller.Patch1(1, complexParameter));
+
+            string body = requestPost2.GetRequest().Content.ReadAsStringAsync().Result;
+            JsonSerializer.Deserialize<Pagination>(body).PageIndex.Should().Be(complexParameter.PageIndex);
+            JsonSerializer.Deserialize<Pagination>(body).PageCount.Should().Be(complexParameter.PageCount);
+            requestPost2.GetConfiguredAddress().StartsWith("api/values/1").Should().Be(true);
         }
 
         private class PrivateNonControllerClass


### PR DESCRIPTION
the [apicontroller] attribute makes it unnecessary to add the [frombody] in the actions post, put, etc since by default it looks in the body, to be able to use this nuget forces me to put that attribute when it is not necessary by .NET Core, with this change we can use the apicontroller attribute and get the body object directly without adding the [frombody]. Also I have fixed a little bug that when you fill some object with null property, when it was attached in the body the call fails. can you review @unaizorrilla or @hbiarge or @Xabaril  and if it's ok merge this changes in the nuget?