### PR TITLE
Fix null reference exception when pass null properties in request model

### DIFF
--- a/src/Acheve.TestHost/Routing/AttributeTemplates/AttributeTemplateSelector.cs
+++ b/src/Acheve.TestHost/Routing/AttributeTemplates/AttributeTemplateSelector.cs
@@ -35,8 +35,7 @@ namespace Acheve.TestHost.Routing.AttributeTemplates
                 string parameter = null;
 
                 regex_pattern = @"{([^\?:}]*)";
-                parameter = Regex.Matches(match.Value, regex_pattern)
-                    .FirstOrDefault()?
+                parameter = Regex.Match(match.Value, regex_pattern)
                     .Groups
                     .Values
                     .LastOrDefault()?

--- a/src/Acheve.TestHost/Routing/AttributeTemplates/AttributeTemplateSelector.cs
+++ b/src/Acheve.TestHost/Routing/AttributeTemplates/AttributeTemplateSelector.cs
@@ -1,5 +1,6 @@
 ﻿using Acheve.TestHost.Routing.Tokenizers;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Acheve.TestHost.Routing.AttributeTemplates
@@ -11,7 +12,7 @@ namespace Acheve.TestHost.Routing.AttributeTemplates
 
         public virtual string SubstituteTokens(string template, TestServerTokenCollection tokens)
         {
-            const string regex_pattern = "{[a-zA-Z0-9]*:??[a-zA-Z0-9]*}";
+            var regex_pattern = "{[a-zA-Z0-9?]*:??[a-zA-Z0-9]*}";
 
             template = template.ToLowerInvariant();
 
@@ -33,17 +34,13 @@ namespace Acheve.TestHost.Routing.AttributeTemplates
             {
                 string parameter = null;
 
-                if (match.Value.Contains(":"))
-                {
-                    //has constraints
-                    parameter = match.Value.Split(':')[0]
-                        .Remove(0, 1); // remove first bracket
-                }
-                else
-                {
-                    parameter = match.Value.Replace("{", string.Empty)
-                        .Replace("}", string.Empty);
-                }
+                regex_pattern = @"{([^\?:}]*)";
+                parameter = Regex.Matches(match.Value, regex_pattern)
+                    .FirstOrDefault()?
+                    .Groups
+                    .Values
+                    .LastOrDefault()?
+                    .Value;
 
                 var token = tokens.Find(parameter);
 
@@ -54,6 +51,9 @@ namespace Acheve.TestHost.Routing.AttributeTemplates
                     token.SetAsUsed();
                 }
             }
+
+            regex_pattern = @"\/{[^{}]*\?}";
+            template = Regex.Replace(template, regex_pattern, string.Empty);
 
             return template.ToLowerInvariant();
         }

--- a/src/Acheve.TestHost/Routing/Tokenizers/ComplexParameterActionTokenizer.cs
+++ b/src/Acheve.TestHost/Routing/Tokenizers/ComplexParameterActionTokenizer.cs
@@ -25,7 +25,10 @@ namespace Acheve.TestHost.Routing.Tokenizers
                             var tokenName = property.Name.ToLowerInvariant();
                             var value = property.GetValue(action.ArgumentValues[i].Instance);
 
-                            tokens.AddToken(tokenName, value.ToString(), isConventional: false);
+                            if (value != null)
+                            {
+                                tokens.AddToken(tokenName, value.ToString(), isConventional: false);
+                            }
                         }
                     }
                 }

--- a/tests/UnitTests/Acheve.TestHost/Routing/Builders/ValuesV3Controller.cs
+++ b/tests/UnitTests/Acheve.TestHost/Routing/Builders/ValuesV3Controller.cs
@@ -13,7 +13,7 @@ namespace UnitTests.Acheve.TestHost.Builders
             return Ok();
         }
 
-        [HttpGet("get2/{pageindex}/{pagecount}")]
+        [HttpGet("get2/{pageindex}/{pagecount?}")]
         public IActionResult Get2([FromQuery]Pagination pagination)
         {
             return Ok();
@@ -25,7 +25,7 @@ namespace UnitTests.Acheve.TestHost.Builders
             return Ok();
         }
 
-        [Route("get4/{pageindex}/{pagecount}"), HttpGet]
+        [Route("get4/{pageindex}/{pagecount?}"), HttpGet]
         public IActionResult Get4([FromQuery]Pagination pagination)
         {
             return Ok();
@@ -82,6 +82,6 @@ namespace UnitTests.Acheve.TestHost.Builders
     {
         public int PageIndex { get; set; }
 
-        public int PageCount { get; set; }
+        public int? PageCount { get; set; }
     }
 }

--- a/tests/UnitTests/Acheve.TestHost/Routing/TestServerExtensionsTests.cs
+++ b/tests/UnitTests/Acheve.TestHost/Routing/TestServerExtensionsTests.cs
@@ -385,6 +385,25 @@ namespace UnitTests.Acheve.TestHost.Routing
         }
 
         [Fact]
+        public void create_valid_request_using_verbs_when_parameters_are_not_primitives_with_null_properties()
+        {
+            var server = new TestServerBuilder()
+            .UseDefaultStartup()
+            .Build();
+
+            var complexParameter = new Pagination()
+            {
+                PageIndex = 1
+            };
+
+            var requestGet = server.CreateHttpApiRequest<ValuesV3Controller>(
+                controller => controller.Get2(complexParameter));
+
+            requestGet.GetConfiguredAddress()
+                .Should().Be("api/values/get2/1");
+        }
+
+        [Fact]
         public void create_valid_request_using_verbs_and_query_string_when_parameters_are_not_primitives()
         {
             var server = new TestServerBuilder()
@@ -402,6 +421,25 @@ namespace UnitTests.Acheve.TestHost.Routing
 
             requestGet.GetConfiguredAddress()
                 .Should().Be("api/values/get1?pageindex=1&pagecount=10");
+        }
+
+        [Fact]
+        public void create_valid_request_using_verbs_and_query_string_when_parameters_are_not_primitives_with_null_properties()
+        {
+            var server = new TestServerBuilder()
+            .UseDefaultStartup()
+            .Build();
+
+            var complexParameter = new Pagination()
+            {
+                PageIndex = 1
+            };
+
+            var requestGet = server.CreateHttpApiRequest<ValuesV3Controller>(
+                controller => controller.Get1(complexParameter));
+
+            requestGet.GetConfiguredAddress()
+                .Should().Be("api/values/get1?pageindex=1");
         }
 
         [Fact]
@@ -425,6 +463,25 @@ namespace UnitTests.Acheve.TestHost.Routing
         }
 
         [Fact]
+        public void create_valid_request_using_route_when_parameters_are_not_primitives_with_null_properties()
+        {
+            var server = new TestServerBuilder()
+            .UseDefaultStartup()
+            .Build();
+
+            var complexParameter = new Pagination()
+            {
+                PageIndex = 1
+            };
+
+            var requestGet = server.CreateHttpApiRequest<ValuesV3Controller>(
+                controller => controller.Get4(complexParameter));
+
+            requestGet.GetConfiguredAddress()
+                .Should().Be("api/values/get4/1");
+        }
+
+        [Fact]
         public void create_valid_request_using_route_and_query_string_when_parameters_are_not_primitives()
         {
             var server = new TestServerBuilder()
@@ -445,6 +502,25 @@ namespace UnitTests.Acheve.TestHost.Routing
         }
 
         [Fact]
+        public void create_valid_request_using_route_and_query_string_when_parameters_are_not_primitives_with_null_properties()
+        {
+            var server = new TestServerBuilder()
+            .UseDefaultStartup()
+            .Build();
+
+            var complexParameter = new Pagination()
+            {
+                PageIndex = 1
+            };
+
+            var requestGet = server.CreateHttpApiRequest<ValuesV3Controller>(
+                controller => controller.Get3(complexParameter));
+
+            requestGet.GetConfiguredAddress()
+                .Should().Be("api/values/get3?pageindex=1");
+        }
+
+        [Fact]
         public void create_valid_request_using_from_body_complex_arguments()
         {
             var server = new TestServerBuilder()
@@ -454,6 +530,25 @@ namespace UnitTests.Acheve.TestHost.Routing
             var complexParameter = new Pagination()
             {
                 PageCount = 10,
+                PageIndex = 1
+            };
+
+            var requestPost = server.CreateHttpApiRequest<ValuesV3Controller>(
+                controller => controller.Post1(complexParameter));
+
+            requestPost.GetConfiguredAddress()
+                .Should().Be("api/values/");
+        }
+
+        [Fact]
+        public void create_valid_request_using_from_body_complex_arguments_with_null_properties()
+        {
+            var server = new TestServerBuilder()
+            .UseDefaultStartup()
+            .Build();
+
+            var complexParameter = new Pagination()
+            {
                 PageIndex = 1
             };
 
@@ -487,6 +582,27 @@ namespace UnitTests.Acheve.TestHost.Routing
         }
 
         [Fact]
+        public void create_valid_request_using_from_form_complex_arguments_with_null_properties()
+        {
+            var server = new TestServerBuilder()
+            .UseDefaultStartup()
+            .Build();
+
+            var complexParameter = new Pagination()
+            {
+                PageIndex = 1
+            };
+
+            var requestPost = server.CreateHttpApiRequest<ValuesV3Controller>(
+                controller => controller.Post3(complexParameter),
+                tokenValues: null,
+                new IncludeContentAsFormUrlEncoded());
+
+            requestPost.GetConfiguredAddress()
+                .Should().Be("api/values/post3");
+        }
+
+        [Fact]
         public void create_valid_request_using_from_body_complex_arguments_and_primitive_query_parameters()
         {
             var server = new TestServerBuilder()
@@ -507,6 +623,25 @@ namespace UnitTests.Acheve.TestHost.Routing
         }
 
         [Fact]
+        public void create_valid_request_using_from_body_complex_arguments_and_primitive_query_parameters_with_null_properties()
+        {
+            var server = new TestServerBuilder()
+            .UseDefaultStartup()
+            .Build();
+
+            var complexParameter = new Pagination()
+            {
+                PageIndex = 1
+            };
+
+            var requestPost = server.CreateHttpApiRequest<ValuesV3Controller>(
+                controller => controller.Post2(2, complexParameter));
+
+            requestPost.GetConfiguredAddress()
+                .Should().Be("api/values/post/2");
+        }
+
+        [Fact]
         public void create_valid_request_using_from_form_complex_arguments_and_primitive_query_parameters()
         {
             var server = new TestServerBuilder()
@@ -516,6 +651,27 @@ namespace UnitTests.Acheve.TestHost.Routing
             var complexParameter = new Pagination()
             {
                 PageCount = 10,
+                PageIndex = 1
+            };
+
+            var requestPost = server.CreateHttpApiRequest<ValuesV3Controller>(
+                controller => controller.Post4(2, complexParameter),
+                tokenValues: null,
+                new IncludeContentAsFormUrlEncoded());
+
+            requestPost.GetConfiguredAddress()
+                .Should().Be("api/values/post4/2");
+        }
+
+        [Fact]
+        public void create_valid_request_using_from_form_complex_arguments_and_primitive_query_parameters_wit_null_properties()
+        {
+            var server = new TestServerBuilder()
+            .UseDefaultStartup()
+            .Build();
+
+            var complexParameter = new Pagination()
+            {
                 PageIndex = 1
             };
 
@@ -635,6 +791,91 @@ namespace UnitTests.Acheve.TestHost.Routing
         }
 
         [Fact]
+        public void create_valid_request_when_action_use_tilde_to_override_controller_route_with_null_properties()
+        {
+            var server = new TestServerBuilder()
+                .UseDefaultStartup()
+                .Build();
+
+            var requestPost = server.CreateHttpApiRequest<ValuesV4Controller>(
+               controller => controller.Get1(1));
+
+            requestPost.GetConfiguredAddress()
+                .Should().Be("get1/1");
+
+            requestPost = server.CreateHttpApiRequest<ValuesV4Controller>(
+               controller => controller.Post1(2));
+
+            requestPost.GetConfiguredAddress()
+                .Should().Be("post1/2");
+
+            requestPost = server.CreateHttpApiRequest<ValuesV4Controller>(
+              controller => controller.Put1(3));
+
+            requestPost.GetConfiguredAddress()
+                .Should().Be("put1/3");
+
+            requestPost = server.CreateHttpApiRequest<ValuesV4Controller>(
+              controller => controller.Delete1(4));
+
+            requestPost.GetConfiguredAddress()
+                .Should().Be("delete1/4");
+
+            var pagination = new Pagination()
+            {
+                PageIndex = 1
+            };
+
+            requestPost = server.CreateHttpApiRequest<ValuesV4Controller>(
+               controller => controller.Get2(1, pagination));
+
+            requestPost.GetConfiguredAddress()
+                .Should().Be("get2/1?pageindex=1");
+
+            requestPost = server.CreateHttpApiRequest<ValuesV4Controller>(
+               controller => controller.Post2(1, pagination));
+
+            requestPost.GetConfiguredAddress()
+                .Should().Be("post2/1?pageindex=1");
+
+            requestPost = server.CreateHttpApiRequest<ValuesV4Controller>(
+               controller => controller.Put2(1, pagination));
+
+            requestPost.GetConfiguredAddress()
+                .Should().Be("put2/1?pageindex=1");
+
+            requestPost = server.CreateHttpApiRequest<ValuesV4Controller>(
+                controller => controller.Delete2(1, pagination));
+
+            requestPost.GetConfiguredAddress()
+                .Should().Be("delete2/1?pageindex=1");
+
+            requestPost = server.CreateHttpApiRequest<ValuesV4Controller>(
+               controller => controller.Get3(1, pagination));
+
+            requestPost.GetConfiguredAddress()
+                .Should().Be("get3/1?pageindex=1");
+
+            requestPost = server.CreateHttpApiRequest<ValuesV4Controller>(
+               controller => controller.Post3(1, pagination));
+
+            requestPost.GetConfiguredAddress()
+                .Should().Be("post3/1?pageindex=1");
+
+            requestPost = server.CreateHttpApiRequest<ValuesV4Controller>(
+               controller => controller.Put3(1, pagination));
+
+            requestPost.GetConfiguredAddress()
+                .Should().Be("put3/1?pageindex=1");
+
+            requestPost = server.CreateHttpApiRequest<ValuesV4Controller>(
+                controller => controller.Delete3(1, pagination));
+
+            requestPost.GetConfiguredAddress()
+                .Should().Be("delete3/1?pageindex=1");
+        }
+
+        [Fact]
         public async Task create_request_including_fromBody_argument_as_content_as_default_behavior()
         {
             var server = new TestServerBuilder()
@@ -644,6 +885,28 @@ namespace UnitTests.Acheve.TestHost.Routing
             var complexParameter = new Pagination()
             {
                 PageCount = 10,
+                PageIndex = 1
+            };
+
+            var request = server.CreateHttpApiRequest<ValuesV3Controller>(
+                controller => controller.Post2(2, complexParameter),
+                tokenValues: null,
+                new IncludeContentAsJson());
+
+            var response = await request.PostAsync();
+
+            await response.IsSuccessStatusCodeOrThrow();
+        }
+
+        [Fact]
+        public async Task create_request_including_fromBody_argument_as_content_as_default_behavior_with_null_properties()
+        {
+            var server = new TestServerBuilder()
+                .UseDefaultStartup()
+                .Build();
+
+            var complexParameter = new Pagination()
+            {
                 PageIndex = 1
             };
 
@@ -681,6 +944,28 @@ namespace UnitTests.Acheve.TestHost.Routing
         }
 
         [Fact]
+        public async Task create_request_including_fromBody_argument_as_content_configured_explicitly_with_null_properties()
+        {
+            var server = new TestServerBuilder()
+                .UseDefaultStartup()
+                .Build();
+
+            var complexParameter = new Pagination()
+            {
+                PageIndex = 1
+            };
+
+            var request = server.CreateHttpApiRequest<ValuesV3Controller>(
+                actionSelector: controller => controller.Post2(2, complexParameter),
+                tokenValues: null,
+                contentOptions: new IncludeContentAsJson());
+
+            var response = await request.PostAsync();
+
+            await response.IsSuccessStatusCodeOrThrow();
+        }
+
+        [Fact]
         public async Task create_request_including_fromForm_argument_as_content_as_default_behavior()
         {
             var server = new TestServerBuilder()
@@ -704,6 +989,28 @@ namespace UnitTests.Acheve.TestHost.Routing
         }
 
         [Fact]
+        public async Task create_request_including_fromForm_argument_as_content_as_default_behavior_with_null_properties()
+        {
+            var server = new TestServerBuilder()
+                .UseDefaultStartup()
+                .Build();
+
+            var complexParameter = new Pagination()
+            {
+                PageIndex = 1
+            };
+
+            var request = server.CreateHttpApiRequest<ValuesV3Controller>(
+                controller => controller.Post4(2, complexParameter),
+                tokenValues: null,
+                new IncludeContentAsFormUrlEncoded());
+
+            var response = await request.PostAsync();
+
+            await response.IsSuccessStatusCodeOrThrow();
+        }
+
+        [Fact]
         public async Task create_request_including_fromForm_argument_as_content_configured_explicitly()
         {
             var server = new TestServerBuilder()
@@ -713,6 +1020,28 @@ namespace UnitTests.Acheve.TestHost.Routing
             var complexParameter = new Pagination()
             {
                 PageCount = 10,
+                PageIndex = 1
+            };
+
+            var request = server.CreateHttpApiRequest<ValuesV3Controller>(
+                actionSelector: controller => controller.Post4(2, complexParameter),
+                tokenValues: null,
+                contentOptions: new IncludeContentAsFormUrlEncoded());
+
+            var response = await request.PostAsync();
+
+            await response.IsSuccessStatusCodeOrThrow();
+        }
+
+        [Fact]
+        public async Task create_request_including_fromForm_argument_as_content_configured_explicitly_with_null_properties()
+        {
+            var server = new TestServerBuilder()
+                .UseDefaultStartup()
+                .Build();
+
+            var complexParameter = new Pagination()
+            {
                 PageIndex = 1
             };
 
@@ -764,6 +1093,42 @@ namespace UnitTests.Acheve.TestHost.Routing
         }
 
         [Fact]
+        public async Task create_request_including_fromForm_argument_as_content_with_complex_object_with_null_properties()
+        {
+            var server = new TestServerBuilder()
+            .UseDefaultStartup()
+            .Build();
+
+            var complexObject = new ComplexObject()
+            {
+                BoolNullableParameter = true,
+                BoolParameter = true,
+                ComplexParameter = new Complex()
+                {
+                    Pagination = new Pagination()
+                    {
+                        PageIndex = 1
+                    },
+                    LongNullableParameter = 1,
+                    LongParameter = 1
+                },
+                IntNullableParameter = 1,
+                IntParameter = 1,
+                StringParameter = "Test",
+                DateTimeParameter = DateTime.Now
+            };
+
+            var request = server.CreateHttpApiRequest<RequestContentController>(
+                controller => controller.Post(complexObject),
+                tokenValues: null,
+                new IncludeContentAsFormUrlEncoded());
+
+            var response = await request.PostAsync();
+
+            await response.IsSuccessStatusCodeOrThrow();
+        }
+
+        [Fact]
         public async Task create_request_not_adding_fromBody_argument_as_content()
         {
             var server = new TestServerBuilder()
@@ -773,6 +1138,28 @@ namespace UnitTests.Acheve.TestHost.Routing
             var complexParameter = new Pagination()
             {
                 PageCount = 10,
+                PageIndex = 1
+            };
+
+            var request = server.CreateHttpApiRequest<ValuesV3Controller>(
+                actionSelector: controller => controller.Post2(2, complexParameter),
+                tokenValues: null,
+                contentOptions: new NotIncludeContent());
+
+            var response = await request.PostAsync();
+
+            response.StatusCode.Should().Be(HttpStatusCode.UnsupportedMediaType);
+        }
+
+        [Fact]
+        public async Task create_request_not_adding_fromBody_argument_as_content_with_null_properties()
+        {
+            var server = new TestServerBuilder()
+                .UseDefaultStartup()
+                .Build();
+
+            var complexParameter = new Pagination()
+            {
                 PageIndex = 1
             };
 


### PR DESCRIPTION
When pass null properties to a request wich have nullable properties then an null reference error is throwing, this PR solves it.

Also I added some tests for ensure that it is working and doesn't break anything else.

