### PR TITLE
Fix exception when you use CreateHttpApiRequest and you call the controller action with null parameters

### DIFF
--- a/samples/Sample.Api/Controllers/ValuesController.cs
+++ b/samples/Sample.Api/Controllers/ValuesController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Sample.Api.Models;
 
 namespace Sample.Api.Controllers
 {
@@ -25,6 +26,24 @@ namespace Sample.Api.Controllers
         public IActionResult PublicValues()
         {
             return Ok(new[] { "Value1", "Value2" });
+        }
+
+        [HttpGet("model")]
+        public IActionResult ModelValues([FromQuery] ValueModel model)
+        {
+            if (model == null)
+                return Values();
+            
+            return Ok(new[] { model.Value });
+        }
+
+        [HttpGet("primitive")]
+        public IActionResult PrimitiveValues(string value)
+        {
+            if (value == null)
+                return Values();
+
+            return Ok(new[] { value });
         }
     }
 }

--- a/samples/Sample.Api/Models/ValueModel.cs
+++ b/samples/Sample.Api/Models/ValueModel.cs
@@ -1,0 +1,7 @@
+﻿namespace Sample.Api.Models
+{
+    public class ValueModel
+    {
+        public string Value { get; set; }
+    }
+}

--- a/samples/Sample.IntegrationTests/Specs/ValuesTests.cs
+++ b/samples/Sample.IntegrationTests/Specs/ValuesTests.cs
@@ -70,5 +70,23 @@ namespace Sample.IntegrationTests.Specs
 
             await response.IsSuccessStatusCodeOrThrow();
         }
+
+        [Fact]
+        public async Task WithRequestBuilderAndNullParameter()
+        {
+            var response = await _fixture.Server.CreateHttpApiRequest<ValuesController>(controller => controller.ModelValues(null))
+                .GetAsync();
+
+            await response.IsSuccessStatusCodeOrThrow();
+        }
+
+        [Fact]
+        public async Task WithRequestBuilderAndNullPrimitiveParameter()
+        {
+            var response = await _fixture.Server.CreateHttpApiRequest<ValuesController>(controller => controller.PrimitiveValues(null))
+                .GetAsync();
+
+            await response.IsSuccessStatusCodeOrThrow();
+        }
     }
 }

--- a/src/Acheve.TestHost/Routing/TestServerAction.cs
+++ b/src/Acheve.TestHost/Routing/TestServerAction.cs
@@ -32,7 +32,7 @@ namespace Acheve.TestHost.Routing
                 {
                     case ConstantExpression constant:
                         {
-                            ArgumentValues.Add(order, new TestServerArgument(constant.Value.ToString(), isFromBody, isFromForm));
+                            ArgumentValues.Add(order, new TestServerArgument(constant.Value?.ToString(), isFromBody, isFromForm));
                         }
                         break;
                     case MemberExpression member when member.NodeType == ExpressionType.MemberAccess:

--- a/src/Acheve.TestHost/Routing/TestServerAction.cs
+++ b/src/Acheve.TestHost/Routing/TestServerAction.cs
@@ -33,7 +33,7 @@ namespace Acheve.TestHost.Routing
                 {
                     case ConstantExpression constant:
                         {
-                            ArgumentValues.Add(order, new TestServerArgument(constant.Value.ToString(), isFromBody, isFromForm, isFromHeader, argument.Name));
+                            ArgumentValues.Add(order, new TestServerArgument(constant.Value?.ToString(), isFromBody, isFromForm, isFromHeader, argument.Name));
                         }
                         break;
                     case MemberExpression member when member.NodeType == ExpressionType.MemberAccess:

--- a/src/Acheve.TestHost/Routing/Tokenizers/ComplexParameterActionTokenizer.cs
+++ b/src/Acheve.TestHost/Routing/Tokenizers/ComplexParameterActionTokenizer.cs
@@ -15,15 +15,16 @@ namespace Acheve.TestHost.Routing.Tokenizers
             for (int i = 0; i < parameters.Length; i++)
             {
                 var type = parameters[i].ParameterType;
+                var instance = action.ArgumentValues[i].Instance;
 
-                if (!(type.IsPrimitive || type == typeof(String) || type == typeof(Decimal) || type == typeof(Guid)))
+                if (instance != null && !(type.IsPrimitive || type == typeof(String) || type == typeof(Decimal) || type == typeof(Guid)))
                 {
                     if (!IgnoreBind(parameters[i]))
                     {
                         foreach (var property in type.GetProperties())
                         {
                             var tokenName = property.Name.ToLowerInvariant();
-                            var value = property.GetValue(action.ArgumentValues[i].Instance);
+                            var value = property.GetValue(instance);
 
                             tokens.AddToken(tokenName, value.ToString(), isConventional: false);
                         }

--- a/src/Acheve.TestHost/Routing/Tokenizers/PrimitiveParameterActionTokenizer.cs
+++ b/src/Acheve.TestHost/Routing/Tokenizers/PrimitiveParameterActionTokenizer.cs
@@ -23,7 +23,10 @@ namespace Acheve.TestHost.Routing.Tokenizers
                     var tokenName = parameters[i].Name.ToLowerInvariant();
                     var tokenValue = action.ArgumentValues[i].Instance;
 
-                    tokens.AddToken(tokenName, tokenValue.ToString(), isConventional: false);
+                    if (tokenValue != null)
+                    {
+                        tokens.AddToken(tokenName, tokenValue.ToString(), isConventional: false);
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Exception when you use CreateHttpApiRequest and you call the controller action with null parameters**

- Two new endpoints with parameters (custom or primitive object)
- Tests calling endpoints with a null parameter (custom or primitive object)
- We check if the instance is null before AddTokken in PrimitiveParameterActionTokenizer and ComplexParameterActionTokenizer
- We add null argument in TestServerAction instead of a null reference exception