### PR TITLE
Enable Source Link

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,3 +1,32 @@
 ﻿<Project>
   <Import Project="build/dependencies.props" />
+
+  <PropertyGroup Label="Package information">
+    <Version>3.1.0</Version>
+    <PackageLicenseUrl>https://github.com/Xabaril/Acheve.TestHost/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>http://github.com/xabaril/Acheve.TestHost</PackageProjectUrl>
+    <RepositoryUrl>http://github.com/xabaril/Acheve.TestHost</RepositoryUrl>
+    <Authors>Xabaril Contributors</Authors>
+    <Company>Xabaril</Company>
+    <Description>Achve.TestHost is a nuget package to improve TestServer experiences.
+    For more information see http://github.com/Xabaril/Acheve.TestHost</Description>
+    <Tags>TestHost;TestServer</Tags>
+
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SourceRoot Include="$(MSBuildThisFileDirectory)/"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGithub)">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -10,22 +10,11 @@
     <JwtBearerVersion>3.1.23</JwtBearerVersion>
     <FluentAssertionsVersion>6.5.1</FluentAssertionsVersion>
     <NewtonsoftJson>13.0.1</NewtonsoftJson>
+    <MicrosoftSourceLinkGithub>1.1.1</MicrosoftSourceLinkGithub>
   </PropertyGroup>
 
-  <PropertyGroup Label="CLI Tools Versions">
+  <PropertyGroup Label="Testing Dependencies">
     <DotnetXUnitPackageVersion>2.4.1</DotnetXUnitPackageVersion>
     <DotnetXUnitRunnerPackageVersion>2.4.3</DotnetXUnitRunnerPackageVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Label="Package information">
-    <PackageLicenseUrl>https://github.com/Xabaril/Acheve.TestHost/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>http://github.com/xabaril/Acheve.TestHost</PackageProjectUrl>
-    <RepositoryUrl>http://github.com/xabaril/Acheve.TestHost</RepositoryUrl>    
-    <Authors>Xabaril Contributors</Authors>
-    <Company>Xabaril</Company>
-    <Version>3.1.0</Version>
-    <Description>Achve.TestHost is a nuget package to improve TestServer experiences.
-    For more information see http://github.com/Xabaril/Acheve.TestHost</Description>
-    <Tags>TestHost;TestServer</Tags>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "projects": [ "src", "test", "samples" ],
   "sdk": {
-    "version": "3.1.100",
+    "version": "3.1.300",
     "rollForward": "latestMajor"
   }
 }

--- a/src/Acheve.TestHost/Acheve.TestHost.csproj
+++ b/src/Acheve.TestHost/Acheve.TestHost.csproj
@@ -2,12 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetCoreTargetVersion)</TargetFramework>
+
+    <Version>$(Version)</Version>
     <PackageLicenseUrl>$(PackageLicenseUrl)</PackageLicenseUrl>
     <PackageProjectUrl>$(PackageProjectUrl)</PackageProjectUrl>
+    <RepositoryUrl>$(RepositoryUrl)</RepositoryUrl>
+    <Authors>$(Authors)</Authors>
+    <Company>$(Company)</Company>
     <Description>$(Description)</Description>
     <PackageTags>$(Tags)</PackageTags>
-    <Version>$(Version)</Version>
-    <RepositoryUrl>$(RepositoryUrl)</RepositoryUrl>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Move "Package information" from "build/dependencies.props" to "Directory.Build.props"
Add Source Link to Github
Minimun version 3.1.300 to avoid issue "https://github.com/dotnet/sourcelink/issues/572"