### PR TITLE
Set targets and versions to Net Core 3.1, Net 5 and Net 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup .NET SDK 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.200
+      - name: Setup .NET SDK 5.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.101
       - name: Setup .NET Core SDK 3.1
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.1.417
       - name: Build .NET 3.1
-        run: dotnet build -c $BUILD_CONFIG
+        run: dotnet build -c $BUILD_CONFIG --framework netcoreapp3.1
+      - name: Build .NET 5.0
+        run: dotnet build -c $BUILD_CONFIG --framework net5.0
+      - name: Build .NET 6.0
+        run: dotnet build -c $BUILD_CONFIG --framework net6.0
       - name: Test
         run: dotnet test -c $BUILD_CONFIG --no-build

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -13,6 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup .NET SDK 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.200
+      - name: Setup .NET SDK 5.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.101
       - name: Setup .NET Core SDK 3.1
         uses: actions/setup-dotnet@v1
         with:

--- a/Acheve.TestHost.sln
+++ b/Acheve.TestHost.sln
@@ -22,6 +22,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{97C5D07D-D623-497A-9DA5-2B3376A4F0DC}"
 	ProjectSection(SolutionItems) = preProject
 		build\dependencies.props = build\dependencies.props
+		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		global.json = global.json
 	EndProjectSection
 EndProject

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,8 @@
   <Import Project="build/dependencies.props" />
 
   <PropertyGroup Label="Package information">
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
+
     <PackageLicenseUrl>https://github.com/Xabaril/Acheve.TestHost/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>http://github.com/xabaril/Acheve.TestHost</PackageProjectUrl>
     <RepositoryUrl>http://github.com/xabaril/Acheve.TestHost</RepositoryUrl>
@@ -10,7 +11,7 @@
     <Company>Xabaril</Company>
     <Description>Achve.TestHost is a nuget package to improve TestServer experiences.
     For more information see http://github.com/Xabaril/Acheve.TestHost</Description>
-    <Tags>TestHost;TestServer</Tags>
+    <PackageTags>TestHost;TestServer</PackageTags>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,34 @@
+﻿<Project>
+	<ItemGroup Label="General Dependencies">
+		<PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
+	</ItemGroup>
+	
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+		<PackageReference Update="Microsoft.AspNetCore.TestHost" Version="$(NetCoreVersion3)" />
+		<PackageReference Update="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(NetCoreVersion3)" />
+	</ItemGroup>
+	
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+		<PackageReference Update="Microsoft.AspNetCore.TestHost" Version="$(NetCoreVersion5)" />
+		<PackageReference Update="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(NetCoreVersion5)" />
+	</ItemGroup>
+	
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+		<PackageReference Update="Microsoft.AspNetCore.TestHost" Version="$(NetCoreVersion6)" />
+		<PackageReference Update="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(NetCoreVersion6)" />
+	</ItemGroup>
+	
+	<ItemGroup Label="Testing Dependencies">
+		<PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+		<PackageReference Update="FluentAssertions" Version="6.5.1" />
+		<PackageReference Update="xunit" Version="2.4.1" />
+		<PackageReference Update="xunit.runner.visualstudio" Version="2.4.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Update="coverlet.collector" Version="3.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+</Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,20 +1,14 @@
 <Project>
   <PropertyGroup Label="SDK Versions">
-    <NetCoreTargetVersion>netcoreapp3.1</NetCoreTargetVersion>
-    <MicrosoftNETTestSdkPackageVersion>17.1.0</MicrosoftNETTestSdkPackageVersion>
+    <NetCoreTargetVersion>netcoreapp3.1;net5.0;net6.0</NetCoreTargetVersion>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-  
-  <PropertyGroup Label="Package Versions">
-    <MicrosoftAspNetCoreTestHostVersion>3.1.23</MicrosoftAspNetCoreTestHostVersion>
-    <JwtBearerVersion>3.1.23</JwtBearerVersion>
-    <FluentAssertionsVersion>6.5.1</FluentAssertionsVersion>
-    <NewtonsoftJson>13.0.1</NewtonsoftJson>
-    <MicrosoftSourceLinkGithub>1.1.1</MicrosoftSourceLinkGithub>
-  </PropertyGroup>
 
-  <PropertyGroup Label="Testing Dependencies">
-    <DotnetXUnitPackageVersion>2.4.1</DotnetXUnitPackageVersion>
-    <DotnetXUnitRunnerPackageVersion>2.4.3</DotnetXUnitRunnerPackageVersion>
+  <PropertyGroup Label="Package Versions">
+    <NetCoreVersion3>3.1.23</NetCoreVersion3>
+    <NetCoreVersion5>5.0.15</NetCoreVersion5>
+    <NetCoreVersion6>6.0.3</NetCoreVersion6>
+
+    <MicrosoftSourceLinkGithub>1.1.1</MicrosoftSourceLinkGithub>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "projects": [ "src", "test", "samples" ],
   "sdk": {
-    "version": "3.1.300",
+    "version": "6.0.100",
     "rollForward": "latestMajor"
   }
 }

--- a/samples/Sample.Api/Sample.Api.csproj
+++ b/samples/Sample.Api/Sample.Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreTargetVersion)</TargetFramework>
+    <TargetFrameworks>$(NetCoreTargetVersion)</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/samples/Sample.Host/Sample.Host.csproj
+++ b/samples/Sample.Host/Sample.Host.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreTargetVersion)</TargetFramework>
+    <TargetFrameworks>$(NetCoreTargetVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(JwtBearerVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Sample.IntegrationTests/Sample.IntegrationTests.csproj
+++ b/samples/Sample.IntegrationTests/Sample.IntegrationTests.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreTargetVersion)</TargetFramework>
+    <TargetFrameworks>$(NetCoreTargetVersion)</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Acheve.TestHost\Acheve.TestHost.csproj" />
-    <ProjectReference Include="..\Sample.Api\Sample.Api.csproj" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(DotnetXUnitRunnerPackageVersion)" />
-    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHostVersion)" />
-    <PackageReference Include="xunit" Version="$(DotnetXUnitPackageVersion)" />
+    <ProjectReference Include="..\..\src\Acheve.TestHost\Acheve.TestHost.csproj" />
+    <ProjectReference Include="..\Sample.Api\Sample.Api.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Acheve.TestHost/Acheve.TestHost.csproj
+++ b/src/Acheve.TestHost/Acheve.TestHost.csproj
@@ -1,16 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreTargetVersion)</TargetFramework>
-
-    <Version>$(Version)</Version>
-    <PackageLicenseUrl>$(PackageLicenseUrl)</PackageLicenseUrl>
-    <PackageProjectUrl>$(PackageProjectUrl)</PackageProjectUrl>
-    <RepositoryUrl>$(RepositoryUrl)</RepositoryUrl>
-    <Authors>$(Authors)</Authors>
-    <Company>$(Company)</Company>
-    <Description>$(Description)</Description>
-    <PackageTags>$(Tags)</PackageTags>
+    <TargetFrameworks>$(NetCoreTargetVersion)</TargetFrameworks>
   </PropertyGroup>
   
   <ItemGroup>
@@ -23,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHostVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJson)" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/tests/UnitTests/UnitTests.csproj
+++ b/tests/UnitTests/UnitTests.csproj
@@ -1,17 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreTargetVersion)</TargetFramework>
-
+    <TargetFrameworks>$(NetCoreTargetVersion)</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHostVersion)" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="xunit" Version="$(DotnetXUnitPackageVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(DotnetXUnitRunnerPackageVersion)" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Application version 3.2.0
Set targets and versions to Net Core 3.1, Net 5 and Net 6
Add Directory.Build.targets with version of nugets
Modify workflows to support Net 5 and Net 6
Clean ".csproj"s